### PR TITLE
修复 Column 装饰器 defaultValue 不生效的问题

### DIFF
--- a/entry/src/main/ets/pages/RdbStoreTest.ets
+++ b/entry/src/main/ets/pages/RdbStoreTest.ets
@@ -18,6 +18,9 @@ class ObservedProduct {
 
   @Field({ type: ColumnType.REAL })
   @Trace price: number = 0;
+
+  @Field({ defaultValue: 'default note' })
+  @Trace note?: string;
 }
 
 @Entry
@@ -188,6 +191,9 @@ struct RdbStoreTest {
         }
         if (queried.name !== '测试商品') {
           throw new Error(`数据错误：name 期望 "测试商品"，实际 "${queried.name}"`);
+        }
+        if (queried.note !== 'default note') {
+          throw new Error(`数据错误: note 期望 "empty note", 实际 "${queried.note}"`);
         }
 
         // 4. 更新

--- a/library/src/main/ets-next/core/ORM.ts
+++ b/library/src/main/ets-next/core/ORM.ts
@@ -518,6 +518,8 @@ export class ORM {
           const value = (entity as Record<string, unknown>)[col.propertyKey];
           if (value !== undefined) {
             values[col.name] = value as ValueType;
+          } else if (isInsert) {
+            values[col.name] = col.defaultValue as ValueType;
           }
         }
       }


### PR DESCRIPTION
现象：@Column 装饰器的 defaultValue 字段不生效
原因：在插入数据表时没有判断如果是空值则使用 defaultValue 值
方案：在 insertSingle 时判断如果某个字段如果是空,且设置了 defaultValue 则使用 defaultValue